### PR TITLE
Update ConfigFlow to limit EntitySelector to Vacuums

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,160 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/custom_components/valetudo_vacuum_camera/config_flow.py
+++ b/custom_components/valetudo_vacuum_camera/config_flow.py
@@ -5,9 +5,10 @@ import logging
 from typing import Any, Dict, Optional
 from homeassistant import config_entries
 
+from homeassistant.components.vacuum import DOMAIN as ZONE_VACUUM
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.selector import EntitySelector, ColorRGBSelector
+from homeassistant.helpers.selector import ColorRGBSelector, EntitySelector, EntitySelectorConfig
 from .const import (
     DOMAIN,
     CONF_VACUUM_ENTITY_ID,
@@ -52,7 +53,9 @@ _LOGGER = logging.getLogger(__name__)
 
 VACUUM_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_VACUUM_ENTITY_ID): EntitySelector(),
+        vol.Required(CONF_VACUUM_ENTITY_ID): EntitySelector(
+            EntitySelectorConfig(domain=ZONE_VACUUM)
+        ),
     }
 )
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,7 +8,7 @@ from custom_components.valetudo_vacuum_camera import config_flow
 @pytest.fixture
 def vacuum_user_input():
     return {
-        config_flow.CONF_VACUUM_ENTITY_ID: "Vacuum Entity ID",
+        config_flow.CONF_VACUUM_ENTITY_ID: "vacuum.entity_id",
     }
 
 
@@ -24,8 +24,8 @@ def mqtt_user_input():
 @pytest.fixture
 def options_user_input():
     return {
-        config_flow.ATT_ROTATE: "Image Rotation",
-        config_flow.ATT_CROP: "Crop Image",
+        config_flow.ATTR_ROTATE: "Image Rotation",
+        config_flow.ATTR_CROP: "Crop Image",
     }
 
 
@@ -100,7 +100,7 @@ async def test_flow_user_creates_config_entry(
     entries = hass.config_entries.async_entries(config_flow.DOMAIN)
     assert len(entries) == 1
     assert entries[0].data == {
-        "vacuum_entity": "Vacuum Entity ID",
+        "vacuum_entity": "vacuum.entity_id",
         "broker_user": "MQTT User Name",
         "broker_password": "MQTT User Password",
         "vacuum_map": "Vacuum Topic Prefix/Identifier",


### PR DESCRIPTION
When you have a lot of entities, being able to limit to the domain that's relevant makes it much easier to parse the list of entities.

I also noticed that there was a broken unit test, so I fixed that and added the [default gitignore for Python from Github](https://github.com/github/gitignore/blob/main/Python.gitignore).