### PR TITLE
Use Home Assistant's MQTT infrastructure instead of rolling our own

### DIFF
--- a/custom_components/valetudo_vacuum_camera/camera.py
+++ b/custom_components/valetudo_vacuum_camera/camera.py
@@ -14,6 +14,7 @@ from homeassistant.const import CONF_NAME
 from homeassistant import core, config_entries
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.typing import (
     ConfigType,
@@ -93,30 +94,30 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-        hass: core.HomeAssistant,
-        config_entry: config_entries.ConfigEntry,
-        async_add_entities,
+    hass: core.HomeAssistant,
+    config_entry: config_entries.ConfigEntry,
+    async_add_entities,
 ) -> None:
     """Setup camera from a config entry created in the integrations UI."""
     config = hass.data[DOMAIN][config_entry.entry_id]
     # Update our config to and eventually add or remove option.
     if config_entry.options:
         config.update(config_entry.options)
-    camera = [ValetudoCamera(Camera, config)]
+    camera = [ValetudoCamera(hass, config)]
     async_add_entities(camera, update_before_add=True)
 
 
 async def async_setup_platform(
-        hass: HomeAssistantType,
-        config: ConfigType,
-        async_add_entities,
-        discovery_info: DiscoveryInfoType | None = None,
+    hass: HomeAssistantType,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
 ):
     async_add_entities([ValetudoCamera(hass, config)])
     await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
 
 
-class ValetudoCamera(Camera, Entity):
+class ValetudoCamera(Camera):
     _attr_has_entity_name = True
 
     def __init__(self, hass, device_info):
@@ -134,9 +135,8 @@ class ValetudoCamera(Camera, Entity):
         self._mqtt_host = device_info.get(CONF_MQTT_HOST)
         self._mqtt_user = device_info.get(CONF_MQTT_USER)
         self._mqtt_pass = device_info.get(CONF_MQTT_PASS)
-        self._mqtt = ValetudoConnector(
-            self._mqtt_host, self._mqtt_user, self._mqtt_pass, self._mqtt_listen_topic, hass
-        )
+        self._mqtt = ValetudoConnector(self._mqtt_listen_topic, self.hass)
+        self._should_poll = True
         self._map_handler = MapImageHandler()
         self._map_rooms = None
         self._vacuum_shared = Vacuum()
@@ -179,7 +179,6 @@ class ValetudoCamera(Camera, Entity):
             self._trim_do = int(device_info.get(ATTR_TRIM_RIGHT))
         else:
             self._trim_right = 0
-        self._image = self.update()
         self._snapshot_taken = False
         self._show_vacuum_state = device_info.get(CONF_VAC_STAT)
         if not self._show_vacuum_state:
@@ -188,7 +187,7 @@ class ValetudoCamera(Camera, Entity):
         self._image_grab = True
         self._frame_nuber = 0
         self.throttled_camera_image = Throttle(timedelta(seconds=5))(self.camera_image)
-        self._should_poll = True
+        self._should_poll = False
         try:
             self.user_colors = [
                 device_info.get(COLOR_WALL),
@@ -229,13 +228,16 @@ class ValetudoCamera(Camera, Entity):
             _LOGGER.error("Error while populating colors: %s", e)
 
     async def async_added_to_hass(self) -> None:
+        await self._mqtt.async_subscribe_to_topics()
+        self._should_poll = True
         self.async_schedule_update_ha_state(True)
 
     async def async_will_remove_from_hass(self) -> None:
         """Handle entity removal from Home Assistant."""
         await super().async_will_remove_from_hass()
-
         # Stop the camera and perform any necessary cleanup tasks here
+        if self._mqtt:
+            await self._mqtt.async_unsubscribe_from_topics()
         self.turn_off()
 
     @property
@@ -243,21 +245,13 @@ class ValetudoCamera(Camera, Entity):
         return 1
 
     def camera_image(
-            self, width: Optional[int] = None, height: Optional[int] = None
+        self, width: Optional[int] = None, height: Optional[int] = None
     ) -> Optional[bytes]:
         return self._image
 
     @property
     def name(self) -> str:
         return self._attr_name
-
-    def turn_on(self):
-        self._mqtt.client_start()
-        self._should_poll = True
-
-    def turn_off(self):
-        self._mqtt.client_stop()
-        self._should_poll = False
 
     @property
     def supported_features(self) -> int:
@@ -318,10 +312,10 @@ class ValetudoCamera(Camera, Entity):
                     self._mqtt.save_payload(self.file_name)
                 # Write the JSON data to the file.
                 with open(
-                        "custom_components/valetudo_vacuum_camera/snapshots/"
-                        + self.file_name
-                        + ".json",
-                        "w",
+                    "custom_components/valetudo_vacuum_camera/snapshots/"
+                    + self.file_name
+                    + ".json",
+                    "w",
                 ) as file:
                     json_data = json.dumps(json_data, indent=4)
                     file.write(json_data)
@@ -340,20 +334,21 @@ class ValetudoCamera(Camera, Entity):
                 self.file_name + ": Snapshot acquired during %s",
                 {self._vacuum_state},
                 " Vacuum State.",
-                )
+            )
 
     def update(self):
         # check and update the vacuum reported state
-        if self._mqtt:
-            self._vacuum_state = self._mqtt.get_vacuum_status()
+        if not self._mqtt:
+            return
         # If we have data from MQTT, we process the image
+        self._vacuum_state = self._mqtt.get_vacuum_status()
         process_data = self._mqtt.is_data_available()
         if process_data:
             # if the vacuum is working, or it is the first image.
             if (
-                    self._vacuum_state == "cleaning"
-                    or self._vacuum_state == "moving"
-                    or self._vacuum_state == "returning"
+                self._vacuum_state == "cleaning"
+                or self._vacuum_state == "moving"
+                or self._vacuum_state == "returning"
             ):
                 # grab the image
                 self._image_grab = True
@@ -365,7 +360,7 @@ class ValetudoCamera(Camera, Entity):
             _LOGGER.info(
                 self.file_name + ": Camera image data update available: %s",
                 process_data,
-                )
+            )
             # calculate the cycle time for frame adjustment
             start_time = datetime.now()
             try:
@@ -402,23 +397,23 @@ class ValetudoCamera(Camera, Entity):
                         _LOGGER.debug(
                             "Applied " + self.file_name + " image rotation: %s",
                             {self._image_rotate},
-                            )
+                        )
                         if self._show_vacuum_state:
                             self._map_handler.draw_status_text(
                                 pil_img,
                                 50,
                                 self._vacuum_shared.user_colors[8],
                                 self.file_name + ": " + self._vacuum_state,
-                                )
+                            )
                         if not self._snapshot_taken and (
-                                self._vacuum_state == "idle"
-                                or self._vacuum_state == "docked"
-                                or self._vacuum_state == "error"
+                            self._vacuum_state == "idle"
+                            or self._vacuum_state == "docked"
+                            or self._vacuum_state == "error"
                         ):
                             # suspend image processing if we are at the next frame.
                             if (
-                                    self._frame_nuber
-                                    is not self._map_handler.get_frame_number()
+                                self._frame_nuber
+                                is not self._map_handler.get_frame_number()
                             ):
                                 self._image_grab = False
                                 _LOGGER.info(
@@ -455,7 +450,7 @@ class ValetudoCamera(Camera, Entity):
                     _LOGGER.debug(
                         "Adjusted " + self.file_name + ": Frame interval: %s",
                         self._frame_interval,
-                        )
+                    )
                 else:
                     _LOGGER.info(
                         self.file_name

--- a/custom_components/valetudo_vacuum_camera/manifest.json
+++ b/custom_components/valetudo_vacuum_camera/manifest.json
@@ -13,5 +13,8 @@
     "pillow",
     "numpy"
   ],
+  "dependencies": [
+    "mqtt"
+  ],
   "version": "v1.3.4"
 }

--- a/custom_components/valetudo_vacuum_camera/valetudo/connector.py
+++ b/custom_components/valetudo_vacuum_camera/valetudo/connector.py
@@ -1,32 +1,18 @@
 """Version 1.3.4"""
 import logging
-import time
-import paho.mqtt.client as client
+from homeassistant.core import callback
+from homeassistant.components import mqtt
 from custom_components.valetudo_vacuum_camera.utils.valetudo_jdata import RawToJson
 
 _LOGGER = logging.getLogger(__name__)
+_QOS = 0
 
 
-class ValetudoConnector(client.Client):
-    def __init__(self, mqtthost, mqttusr, mqttpass, mqtt_topic, hass):
-        super().__init__("valetudo_connector")
+class ValetudoConnector:
+    def __init__(self, mqtt_topic, hass):
+        self._hass = hass
         self._mqtt_topic = mqtt_topic
-        if mqtt_topic:
-            self._mqtt_subscribe = ([
-                (str(mqtt_topic + "/MapData/map-data-hass"), 0),
-                (str(mqtt_topic + "/StatusStateAttribute/status"), 0),
-                (str(mqtt_topic + "/StatusStateAttribute/error_description"), 0),
-            ])
-        self._broker = mqtthost
-        if not self._broker:
-            self._broker = "core-mosquitto"
-        self.username_pw_set(username=mqttusr, password=mqttpass)
-        self.on_connect = self.on_connect_callback
-        self.on_message = self.on_message_callback
-        self.connect_async(host=self._broker, port=1883)
-        self.enable_bridge_mode()
-        self.loop_start()
-        self._mqtt_run = False
+        self._unsubscribe_handlers = []
         self._rcv_topic = None
         self._payload = None
         self._img_payload = None
@@ -34,7 +20,6 @@ class ValetudoConnector(client.Client):
         self._mqtt_vac_err = None
         self._data_in = False
         self._img_decoder = RawToJson(hass)
-        self.is_client_check_mode(mqtt_topic)
 
     def update_data(self, process: bool = True):
         if self._img_payload:
@@ -71,8 +56,10 @@ class ValetudoConnector(client.Client):
                 file.write(self._img_payload)
             _LOGGER.info("Saved image data from MQTT in mqtt_" + file_name + ".raw!")
 
-    def on_message_callback(self, client, userdata, msg):
+    @callback
+    async def async_message_received(self, msg):
         self._rcv_topic = msg.topic
+
         if self._rcv_topic == (self._mqtt_topic + "/MapData/map-data-hass"):
             _LOGGER.debug("Received " + self._mqtt_topic + " image data from MQTT")
             self._img_payload = msg.payload
@@ -100,43 +87,19 @@ class ValetudoConnector(client.Client):
                 + " from MQTT"
             )
 
-    def on_connect_callback(self, client, userdata, flags, rc):
-        self.subscribe(self._mqtt_subscribe)
-        _LOGGER.debug("Subscribed to MQTT broker with topic: " + self._mqtt_topic)
-
-    def stop_and_disconnect(self):
-        self.loop_stop(force=False)  # Stop the MQTT loop gracefully
-        self.disconnect()  # Disconnect from the broker
-        _LOGGER.debug(self._mqtt_topic + ": Stopped and disconnected from MQTT broker.")
-
-    def connect_broker(self):
-        self.connect_async(host=self._broker, port=1883)
-        self.enable_bridge_mode()
-        self.loop_start()
-        _LOGGER.debug(self._mqtt_topic + ": Connect MQTT broker.")
-
-    def client_start(self):
-        self.loop_start()
-        _LOGGER.debug(self._mqtt_topic + ": Started MQTT loop")
-
-    def client_stop(self):
-        self.loop_stop()
-        self._mqtt_run = False
-        _LOGGER.debug(self._mqtt_topic + ": Stopped MQTT loop")
-
-    def is_client_check_mode(self, check_topic):
-        test_topic = "valetudo/myTopic"
-        if check_topic is test_topic:
-            _LOGGER.warning("Valetudo Connector test Topic ON %s", {check_topic})
-            try:
-                with open("tests/mqtt_data.raw", "rb") as file:
-                    binary_data = file.read()
-                self._img_payload = binary_data
-                self._data_in = True
-                self.update_data()
-            except FileExistsError:
-                _LOGGER.warning(
-                    "Valetudo Connector undefined Topic, please check your configuration."
+    async def async_subscribe_to_topics(self):
+        if self._mqtt_topic:
+            for x in [
+                self._mqtt_topic + "/MapData/map-data-hass",
+                self._mqtt_topic + "/StatusStateAttribute/status",
+                self._mqtt_topic + "/StatusStateAttribute/error_description",
+            ]:
+                self._unsubscribe_handlers.append(
+                    await mqtt.async_subscribe(
+                        self._hass, x, self.async_message_received, _QOS, encoding=None
+                    )
                 )
-            time.sleep(1.5)
-            self.loop_stop()
+
+    async def async_unsubscribe_from_topics(self):
+        for x in self._unsubscribe_handlers:
+            await x()


### PR DESCRIPTION
Removes the need for providing any MQTT connection information since we can just use Home Assistant's connection instead.

See: https://github.com/sca075/valetudo_vacuum_camera/discussions/17