### PR TITLE
Remove all manual configuration of MQTT parameters

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "ludeeus/integration_blueprint",
-    "image": "mcr.microsoft.com/vscode/devcontainers/python:0-3.10-bullseye",
+    "image": "mcr.microsoft.com/vscode/devcontainers/python:0-3.11-bullseye",
     "postCreateCommand": "scripts/setup",
     "forwardPorts": [
         8123

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Remote Attach",
+            "type": "python",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 5678
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "."
+                }
+            ],
+            "justMyCode": false
+        }
+    ]
+}

--- a/custom_components/valetudo_vacuum_camera/common.py
+++ b/custom_components/valetudo_vacuum_camera/common.py
@@ -1,0 +1,30 @@
+import logging
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+def get_device_info(config_entry_id: str, hass: HomeAssistant) -> str:
+    """
+    Fetches the vacuum's entity ID and Device from the
+    entity registry and device registry.
+    """
+    vacuum_entity_id = er.async_resolve_entity_id(er.async_get(hass), config_entry_id)
+
+    if not vacuum_entity_id:
+        _LOGGER.error("Unable to lookup vacuum's entity ID. Was it removed?")
+        return None
+
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+    vacuum_device = device_registry.async_get(
+        entity_registry.async_get(vacuum_entity_id).device_id
+    )
+
+    if not vacuum_device:
+        _LOGGER.error("Unable to locate vacuum's device ID. Was it removed?")
+        return None
+
+    return (vacuum_entity_id, vacuum_device)

--- a/custom_components/valetudo_vacuum_camera/const.py
+++ b/custom_components/valetudo_vacuum_camera/const.py
@@ -17,6 +17,8 @@ CONF_MQTT_PASS = "broker_password"
 CONF_MQTT_USER = "broker_user"
 CONF_VACUUM_CONNECTION_STRING = "vacuum_map"
 CONF_VACUUM_ENTITY_ID = "vacuum_entity"
+CONF_VACUUM_CONFIG_ENTRY_ID = "vacuum_config_entry"
+CONF_VACUUM_IDENTIFIERS = "vacuum_identifiers"
 ICON = "mdi:camera"
 NAME = "Valetudo Vacuum Camera"
 

--- a/custom_components/valetudo_vacuum_camera/manifest.json
+++ b/custom_components/valetudo_vacuum_camera/manifest.json
@@ -9,7 +9,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/sca075/valetudo_vacuum_camera/issues",
   "requirements": [
-    "paho-mqtt",
     "pillow",
     "numpy"
   ],

--- a/custom_components/valetudo_vacuum_camera/snapshots/read.me
+++ b/custom_components/valetudo_vacuum_camera/snapshots/read.me
@@ -1,1 +1,0 @@
-snapshot folder added since v1.1.5

--- a/custom_components/valetudo_vacuum_camera/valetudo/connector.py
+++ b/custom_components/valetudo_vacuum_camera/valetudo/connector.py
@@ -101,5 +101,4 @@ class ValetudoConnector:
                 )
 
     async def async_unsubscribe_from_topics(self):
-        for x in self._unsubscribe_handlers:
-            await x()
+        map(lambda x: x(), self._unsubscribe_handlers)

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,16 +1,15 @@
 # From our manifest.json for our custom component
-paho-mqtt==1.6.1
 pillow==9.5.0
 numpy==1.23.2
 
 # Strictly for tests
-coverage==7.2.1
-pytest==7.2.2
-pytest-asyncio==0.20.3
-pytest-cov==3.0.0
-pytest-socket==0.5.1
+coverage==7.2.7
+pytest==7.3.1
+pytest-asyncio==0.21.0
+pytest-cov==4.1.0
+pytest-socket==0.6.0
 pytest-mqtt == 0.2.0
-pytest-homeassistant-custom-component==0.13.20
+pytest-homeassistant-custom-component==0.13.53
 
 #pytest-asyncio==0.20.2
 #pytest-xdist==2.5.0


### PR DESCRIPTION
Hi @sca075,

I'm pushing this branch with my latest work. A few things to note:

1. **There is a Breaking Change,** requiring deleting the integration and re-adding it. This is because previous versions of the config entry did not save the entity_id of the vacuum that was selected in step 1 of the config flow. Because that is not present, there is no easy way to automatically map back to the camera from only the mqtt_topic information.
2. I had to make some changes to the vscode setup as well the devcontainer to upgrade the version of Home Assistant it had to the latest version.
3. At this point, the only configuration required is that you select the vacuum, the rest is automatically done for you and then the config entry is linked to the Vacuum device as well. This will persist even when changes are made to any of the entity IDs because we keep track of the config entry's ID which will not change.
4. It looks like a lot of my previous work from #23 got undone in this commit: https://github.com/sca075/valetudo_vacuum_camera/commit/10333708fa1d3db81ba858bc85a59887e4ac8ecf - I'm guessing you started working with an outdated copy of the code and rather than merging things back in, it looks like it overwrote the changes from the main branch with your changes. Are you able to fix that? I've tried walking it back a couple of times, but it becomes a big mess and it's late here :)

Thanks!

Rohan