### PR TITLE
Adding Configurable Transparecy Level to the map Colours. 

### DIFF
--- a/custom_components/valetudo_vacuum_camera/const.py
+++ b/custom_components/valetudo_vacuum_camera/const.py
@@ -38,8 +38,7 @@ COLOR_ZONE_CLEAN = "color_zone_clean"
 COLOR_WALL = "color_wall"
 COLOR_TEXT = "color_text"
 
-"""Base Colours RGB array
-currently not in use."""
+"""Base Colours RGB array, not in use"""
 CONF_COLORS = [
     COLOR_WALL,
     COLOR_ZONE_CLEAN,


### PR DESCRIPTION
At current is not possible to add transparency to the configured colours.
With this modification the configuration process of the camera will offer, after the camera is configured and validated from HA, to configure the transparency of the colours used to generate the map image (from the camera options. 
