### PR TITLE
Fix bugs in 1.4.1

### DIFF
--- a/custom_components/valetudo_vacuum_camera/__init__.py
+++ b/custom_components/valetudo_vacuum_camera/__init__.py
@@ -27,7 +27,7 @@ PLATFORMS = [Platform.CAMERA]
 
 
 async def options_update_listener(
-        hass: core.HomeAssistant, config_entry: config_entries.ConfigEntry
+    hass: core.HomeAssistant, config_entry: config_entries.ConfigEntry
 ):
     """Handle options update."""
     await hass.config_entries.async_reload(config_entry.entry_id)
@@ -36,7 +36,7 @@ async def options_update_listener(
 async def async_migrate_entry(hass, config_entry: config_entries.ConfigEntry):
     mqtt_topic_base = ""
     """Migrate old entry."""
-    _LOGGER.debug("Migrating from version %s", config_entry.version)
+    _LOGGER.debug("Migrating config entry from version %s", config_entry.version)
 
     if config_entry.version == 1.2:
         new_data = {**config_entry.data}
@@ -85,7 +85,7 @@ async def async_migrate_entry(hass, config_entry: config_entries.ConfigEntry):
     if config_entry.version <= 2.0:
         new_data = {**config_entry.data}
         if config_entry.version < 2.0:
-            _LOGGER.debug("Migration for version 1.4.0 in progress.")
+            _LOGGER.debug("Migration for integration version 1.4.0 in progress.")
             new_data.pop(CONF_MQTT_HOST, None)
             new_data.pop(CONF_MQTT_USER, None)
             new_data.pop(CONF_MQTT_PASS, None)
@@ -93,7 +93,7 @@ async def async_migrate_entry(hass, config_entry: config_entries.ConfigEntry):
             mqtt_topic_base = new_data.pop(CONF_VACUUM_CONNECTION_STRING, None)
             if not mqtt_topic_base:
                 _LOGGER.error(
-                    "Unable to migrate to version 2.0. Could not find %s. Please recreate this entry.",
+                    "Unable to migrate to config entry version 2.0. Could not find %s. Please recreate this entry.",
                     CONF_VACUUM_CONNECTION_STRING,
                 )
                 return False
@@ -102,7 +102,7 @@ async def async_migrate_entry(hass, config_entry: config_entries.ConfigEntry):
             config_entry_id = get_entity_identifier_from_mqtt(mqtt_identifier, hass)
             if not config_entry_id:
                 _LOGGER.error(
-                    "Unable to migrate to version 2.0. Could not find a device for %s. Please recreate this entry.",
+                    "Unable to migrate to config entry version 2.0. Could not find a device for %s. Please recreate this entry.",
                     mqtt_topic_base,
                 )
                 return False
@@ -111,103 +111,104 @@ async def async_migrate_entry(hass, config_entry: config_entries.ConfigEntry):
                     CONF_VACUUM_CONFIG_ENTRY_ID: config_entry_id,
                 }
             )
-            _LOGGER.debug("Migrating to version 2.0 completed..")
-        _LOGGER("config update for v1.4.1 in progress...")
-        if mqtt_topic_base is not "":
-            config_entry.unique_id = get_vacuum_unique_id_from_mqtt_topic(mqtt_topic_base)
+            _LOGGER.debug("Migrating to config entry version 2.0 completed..")
+        _LOGGER.debug("Migration for integration version 1.4.1 in progress.")
+        if mqtt_topic_base:
+            config_entry.unique_id = get_vacuum_unique_id_from_mqtt_topic(
+                mqtt_topic_base
+            )
         else:
             config_entry.unique_id = new_data.pop("unique_id", None)
         _LOGGER.debug("Updating unique_id .. to %s", config_entry.unique_id)
         if not config_entry.unique_id:
-            _LOGGER.error("Migration Failed, please reconfigure Valetudo Vacuum Camera.")
+            _LOGGER.error(
+                "Migration Failed, please reconfigure Valetudo Vacuum Camera."
+            )
             return False
 
         new_options = {**config_entry.options}
 
+        keys_to_migrate = [
+            "rotate_image",
+            "crop_image",
+            "trim_top",
+            "trim_bottom",
+            "trim_left",
+            "trim_right",
+            "show_vac_status",
+            "color_charger",
+            "color_move",
+            "color_wall",
+            "color_robot",
+            "color_go_to",
+            "color_zone_clean",
+            "color_background",
+            "color_text",
+            "color_no_go",
+            "color_room_0",
+            "color_room_1",
+            "color_room_2",
+            "color_room_3",
+            "color_room_4",
+            "color_room_5",
+            "color_room_6",
+            "color_room_7",
+            "color_room_8",
+            "color_room_9",
+            "color_room_10",
+            "color_room_11",
+            "color_room_12",
+            "color_room_13",
+            "color_room_14",
+            "color_room_15",
+        ]
         if len(dict(new_options)) == 0:
-            _LOGGER.debug("Camera Options not in the Configuration..")
-            new_options["rotate_image"] = new_data["rotate_image"]
-            new_options["crop_image"] = new_data["crop_image"]
-            new_options["trim_top"] = new_data["trim_top"]
-            new_options["trim_bottom"] = new_data["trim_bottom"]
-            new_options["trim_left"] = new_data["trim_left"]
-            new_options["show_vac_status"] = new_data["show_vac_status"]
-            new_options["color_charger"] = new_data["color_charger"]
-            new_options["color_move"] = new_data["color_move"]
-            new_options["color_wall"] = new_data["color_wall"]
-            new_options["color_robot"] = new_data["color_robot"]
-            new_options["color_no_go"] = new_data["color_no_go"]
-            new_options["color_zone_clean"] = new_data["color_zone_clean"]
-            new_options["color_background"] = new_data["color_background"]
-            new_options["color_text"] = new_data["color_text"]
-            new_options["color_room_0"] = new_data["color_room_0"]
-            new_options["color_room_1"] = new_data["color_room_1"]
-            new_options["color_room_2"] = new_data["color_room_2"]
-            new_options["color_room_3"] = new_data["color_room_3"]
-            new_options["color_room_4"] = new_data["color_room_4"]
-            new_options["color_room_5"] = new_data["color_room_5"]
-            new_options["color_room_6"] = new_data["color_room_6"]
-            new_options["color_room_7"] = new_data["color_room_7"]
-            new_options["color_room_8"] = new_data["color_room_8"]
-            new_options["color_room_9"] = new_data["color_room_9"]
-            new_options["color_room_10"] = new_data["color_room_10"]
-            new_options["color_room_11"] = new_data["color_room_11"]
-            new_options["color_room_12"] = new_data["color_room_12"]
-            new_options["color_room_13"] = new_data["color_room_13"]
-            new_options["color_room_14"] = new_data["color_room_14"]
-            new_options["color_room_15"] = new_data["color_room_15"]
-
-        _LOGGER.debug("Config Entry data Clean up...")
-        # Remove unwanted data from new_data
-        unwanted_keys = ["rotate_image", "crop_image", "trim_top", "trim_bottom",
-                         "trim_left", "trim_right", "show_vac_status", "color_charger",
-                         "color_move", "color_wall", "color_robot", "color_go_to",
-                         "color_zone_clean", "color_background", "color_text", "color_no_go",
-                         "color_room_0", "color_room_1", "color_room_2", "color_room_3",
-                         "color_room_4", "color_room_5", "color_room_6", "color_room_7",
-                         "color_room_8", "color_room_9", "color_room_10", "color_room_11",
-                         "color_room_12", "color_room_13", "color_room_14", "color_room_15"]
-        for key in unwanted_keys:
-            new_data.pop(key, None)
+            new_options.update((k, new_data.pop(k)) for k in keys_to_migrate)
 
         _LOGGER.debug("Adding Transparency data to the Options..")
-        new_options.update({"alpha_charger": 255.0,
-                            "alpha_move": 255.0,
-                            "alpha_wall": 255.0,
-                            "alpha_robot": 255.0,
-                            "alpha_go_to": 255.0,
-                            "alpha_no_go": 25.0,
-                            "alpha_zone_clean": 25.0,
-                            "alpha_background": 255.0,
-                            "alpha_text": 255.0,
-                            "alpha_room_0": 255.0,
-                            "alpha_room_1": 255.0,
-                            "alpha_room_2": 255.0,
-                            "alpha_room_3": 255.0,
-                            "alpha_room_4": 255.0,
-                            "alpha_room_5": 255.0,
-                            "alpha_room_6": 255.0,
-                            "alpha_room_7": 255.0,
-                            "alpha_room_8": 255.0,
-                            "alpha_room_9": 255.0,
-                            "alpha_room_10": 255.0,
-                            "alpha_room_11": 255.0,
-                            "alpha_room_12": 255.0,
-                            "alpha_room_13": 255.0,
-                            "alpha_room_14": 255.0,
-                            "alpha_room_15": 255.0
-                            })
+        new_options.update(
+            {
+                "alpha_charger": 255.0,
+                "alpha_move": 255.0,
+                "alpha_wall": 255.0,
+                "alpha_robot": 255.0,
+                "alpha_go_to": 255.0,
+                "alpha_no_go": 25.0,
+                "alpha_zone_clean": 25.0,
+                "alpha_background": 255.0,
+                "alpha_text": 255.0,
+                "alpha_room_0": 255.0,
+                "alpha_room_1": 255.0,
+                "alpha_room_2": 255.0,
+                "alpha_room_3": 255.0,
+                "alpha_room_4": 255.0,
+                "alpha_room_5": 255.0,
+                "alpha_room_6": 255.0,
+                "alpha_room_7": 255.0,
+                "alpha_room_8": 255.0,
+                "alpha_room_9": 255.0,
+                "alpha_room_10": 255.0,
+                "alpha_room_11": 255.0,
+                "alpha_room_12": 255.0,
+                "alpha_room_13": 255.0,
+                "alpha_room_14": 255.0,
+                "alpha_room_15": 255.0,
+            }
+        )
 
         config_entry.version = 2.1
-        hass.config_entries.async_update_entry(config_entry, data=new_data)
-        hass.config_entries.async_update_entry(config_entry, options=new_options)
+        hass.config_entries.async_update_entry(
+            config_entry, data=new_data, options=new_options
+        )
 
-    _LOGGER.info("Migration to version %s successful", config_entry.version)
+    _LOGGER.info(
+        "Migration to config entry version %s successful", config_entry.version
+    )
     return True
 
 
 async def async_setup_entry(
-        hass: core.HomeAssistant, entry: config_entries.ConfigEntry
+    hass: core.HomeAssistant, entry: config_entries.ConfigEntry
 ) -> bool:
     """Set up platform from a ConfigEntry."""
     hass.data.setdefault(DOMAIN, {})
@@ -248,7 +249,7 @@ async def async_setup_entry(
 
 
 async def async_unload_entry(
-        hass: core.HomeAssistant, entry: config_entries.ConfigEntry
+    hass: core.HomeAssistant, entry: config_entries.ConfigEntry
 ) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):

--- a/custom_components/valetudo_vacuum_camera/camera.py
+++ b/custom_components/valetudo_vacuum_camera/camera.py
@@ -45,20 +45,56 @@ from .const import (
     ATTR_TRIM_BOTTOM,
     ATTR_TRIM_LEFT,
     ATTR_TRIM_RIGHT,
-    COLOR_WALL, COLOR_ZONE_CLEAN, COLOR_ROBOT,
-    COLOR_BACKGROUND, COLOR_MOVE, COLOR_CHARGER,
-    COLOR_TEXT, COLOR_NO_GO, COLOR_GO_TO, COLOR_ROOM_0,
-    COLOR_ROOM_1, COLOR_ROOM_2, COLOR_ROOM_3, COLOR_ROOM_4,
-    COLOR_ROOM_5, COLOR_ROOM_6, COLOR_ROOM_7, COLOR_ROOM_8,
-    COLOR_ROOM_9, COLOR_ROOM_10, COLOR_ROOM_11, COLOR_ROOM_12,
-    COLOR_ROOM_13, COLOR_ROOM_14, COLOR_ROOM_15,
-    ALPHA_WALL, ALPHA_ZONE_CLEAN, ALPHA_ROBOT,
-    ALPHA_BACKGROUND, ALPHA_MOVE, ALPHA_CHARGER,
-    ALPHA_TEXT, ALPHA_NO_GO, ALPHA_GO_TO, ALPHA_ROOM_0,
-    ALPHA_ROOM_1, ALPHA_ROOM_2, ALPHA_ROOM_3, ALPHA_ROOM_4,
-    ALPHA_ROOM_5, ALPHA_ROOM_6, ALPHA_ROOM_7, ALPHA_ROOM_8,
-    ALPHA_ROOM_9, ALPHA_ROOM_10, ALPHA_ROOM_11, ALPHA_ROOM_12,
-    ALPHA_ROOM_13, ALPHA_ROOM_14, ALPHA_ROOM_15,
+    COLOR_WALL,
+    COLOR_ZONE_CLEAN,
+    COLOR_ROBOT,
+    COLOR_BACKGROUND,
+    COLOR_MOVE,
+    COLOR_CHARGER,
+    COLOR_TEXT,
+    COLOR_NO_GO,
+    COLOR_GO_TO,
+    COLOR_ROOM_0,
+    COLOR_ROOM_1,
+    COLOR_ROOM_2,
+    COLOR_ROOM_3,
+    COLOR_ROOM_4,
+    COLOR_ROOM_5,
+    COLOR_ROOM_6,
+    COLOR_ROOM_7,
+    COLOR_ROOM_8,
+    COLOR_ROOM_9,
+    COLOR_ROOM_10,
+    COLOR_ROOM_11,
+    COLOR_ROOM_12,
+    COLOR_ROOM_13,
+    COLOR_ROOM_14,
+    COLOR_ROOM_15,
+    ALPHA_WALL,
+    ALPHA_ZONE_CLEAN,
+    ALPHA_ROBOT,
+    ALPHA_BACKGROUND,
+    ALPHA_MOVE,
+    ALPHA_CHARGER,
+    ALPHA_TEXT,
+    ALPHA_NO_GO,
+    ALPHA_GO_TO,
+    ALPHA_ROOM_0,
+    ALPHA_ROOM_1,
+    ALPHA_ROOM_2,
+    ALPHA_ROOM_3,
+    ALPHA_ROOM_4,
+    ALPHA_ROOM_5,
+    ALPHA_ROOM_6,
+    ALPHA_ROOM_7,
+    ALPHA_ROOM_8,
+    ALPHA_ROOM_9,
+    ALPHA_ROOM_10,
+    ALPHA_ROOM_11,
+    ALPHA_ROOM_12,
+    ALPHA_ROOM_13,
+    ALPHA_ROOM_14,
+    ALPHA_ROOM_15,
 )
 from .common import get_vacuum_unique_id_from_mqtt_topic
 
@@ -76,9 +112,9 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-        hass: core.HomeAssistant,
-        config_entry: config_entries.ConfigEntry,
-        async_add_entities,
+    hass: core.HomeAssistant,
+    config_entry: config_entries.ConfigEntry,
+    async_add_entities,
 ) -> None:
     """Setup camera from a config entry created in the integrations UI."""
     config = hass.data[DOMAIN][config_entry.entry_id]
@@ -91,10 +127,10 @@ async def async_setup_entry(
 
 
 async def async_setup_platform(
-        hass: HomeAssistantType,
-        config: ConfigType,
-        async_add_entities: AddEntitiesCallback,
-        discovery_info: DiscoveryInfoType | None = None,
+    hass: HomeAssistantType,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
 ):
     async_add_entities([ValetudoCamera(hass, config)])
     await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
@@ -114,7 +150,7 @@ class ValetudoCamera(Camera):
             self._mqtt_listen_topic = str(self._mqtt_listen_topic)
             file_name = self._mqtt_listen_topic.split("/")
             self.snapshot_img = (
-                    self._directory_path + "/www/snapshot_" + file_name[1].lower() + ".png"
+                self._directory_path + "/www/snapshot_" + file_name[1].lower() + ".png"
             )
             self._attr_name = "Camera"
             self._attr_unique_id = device_info.get(
@@ -137,36 +173,12 @@ class ValetudoCamera(Camera):
         self._attr_calibration_points = None
         self._base = None
         self._current = None
-        self._image_rotate = device_info.get(ATTR_ROTATE)
-        if self._image_rotate:
-            self._image_rotate = int(device_info.get(ATTR_ROTATE))
-        else:
-            self._image_rotate = 0
-        self._image_crop = device_info.get(ATTR_CROP)
-        if self._image_crop:
-            self._image_crop = int(device_info.get(ATTR_CROP))
-        else:
-            self._image_crop = 0
-        self._trim_up = device_info.get(ATTR_TRIM_TOP)
-        if self._trim_up:
-            self._trim_up = int(device_info.get(ATTR_TRIM_TOP))
-        else:
-            self._trim_up = 0
-        self._trim_down = device_info.get(ATTR_TRIM_BOTTOM)
-        if self._trim_down:
-            self._trim_do = int(device_info.get(ATTR_TRIM_BOTTOM))
-        else:
-            self._trim_down = 0
-        self._trim_left = device_info.get(ATTR_TRIM_LEFT)
-        if self._trim_down:
-            self._trim_do = int(device_info.get(ATTR_TRIM_LEFT))
-        else:
-            self._trim_left = 0
-        self._trim_right = device_info.get(ATTR_TRIM_RIGHT)
-        if self._trim_down:
-            self._trim_do = int(device_info.get(ATTR_TRIM_RIGHT))
-        else:
-            self._trim_right = 0
+        self._image_rotate = int(device_info.get(ATTR_ROTATE, 0))
+        self._image_crop = int(device_info.get(ATTR_CROP, 0))
+        self._trim_up = int(device_info.get(ATTR_TRIM_TOP, 0))
+        self._trim_down = int(device_info.get(ATTR_TRIM_BOTTOM, 0))
+        self._trim_left = int(device_info.get(ATTR_TRIM_LEFT, 0))
+        self._trim_right = int(device_info.get(ATTR_TRIM_RIGHT, 0))
         self._snapshot_taken = False
         self._show_vacuum_state = device_info.get(CONF_VAC_STAT)
         if not self._show_vacuum_state:
@@ -261,7 +273,7 @@ class ValetudoCamera(Camera):
         return 1
 
     def camera_image(
-            self, width: Optional[int] = None, height: Optional[int] = None
+        self, width: Optional[int] = None, height: Optional[int] = None
     ) -> Optional[bytes]:
         """Camera Image"""
         return self._image
@@ -363,7 +375,7 @@ class ValetudoCamera(Camera):
                 self.file_name + ": Snapshot acquired during %s",
                 {self._vacuum_state},
                 " Vacuum State.",
-                )
+            )
 
     def update(self):
         """Camera Frame Update"""
@@ -376,9 +388,9 @@ class ValetudoCamera(Camera):
         if process_data:
             # if the vacuum is working, or it is the first image.
             if (
-                    self._vacuum_state == "cleaning"
-                    or self._vacuum_state == "moving"
-                    or self._vacuum_state == "returning"
+                self._vacuum_state == "cleaning"
+                or self._vacuum_state == "moving"
+                or self._vacuum_state == "returning"
             ):
                 # grab the image
                 self._image_grab = True
@@ -390,7 +402,7 @@ class ValetudoCamera(Camera):
             _LOGGER.info(
                 self.file_name + ": Camera image data update available: %s",
                 process_data,
-                )
+            )
             # calculate the cycle time for frame adjustment
             start_time = datetime.now()
             try:
@@ -427,23 +439,23 @@ class ValetudoCamera(Camera):
                         _LOGGER.debug(
                             "Applied " + self.file_name + " image rotation: %s",
                             {self._image_rotate},
-                            )
+                        )
                         if self._show_vacuum_state:
                             self._map_handler.draw_status_text(
                                 pil_img,
                                 50,
                                 self._vacuum_shared.user_colors[8],
                                 self.file_name + ": " + self._vacuum_state,
-                                )
+                            )
                         if not self._snapshot_taken and (
-                                self._vacuum_state == "idle"
-                                or self._vacuum_state == "docked"
-                                or self._vacuum_state == "error"
+                            self._vacuum_state == "idle"
+                            or self._vacuum_state == "docked"
+                            or self._vacuum_state == "error"
                         ):
                             # suspend image processing if we are at the next frame.
                             if (
-                                    self._frame_nuber
-                                    is not self._map_handler.get_frame_number()
+                                self._frame_nuber
+                                is not self._map_handler.get_frame_number()
                             ):
                                 self._image_grab = False
                                 _LOGGER.info(
@@ -480,7 +492,7 @@ class ValetudoCamera(Camera):
                     _LOGGER.debug(
                         "Adjusted " + self.file_name + ": Frame interval: %s",
                         self._frame_interval,
-                        )
+                    )
                 else:
                     _LOGGER.info(
                         self.file_name

--- a/custom_components/valetudo_vacuum_camera/config_flow.py
+++ b/custom_components/valetudo_vacuum_camera/config_flow.py
@@ -14,12 +14,13 @@ from homeassistant.helpers.selector import (
     EntitySelectorConfig,
     NumberSelector,
     NumberSelectorConfig,
-    BooleanSelector
+    BooleanSelector,
 )
 from homeassistant.helpers import entity_registry as er
 from .const import (
     DOMAIN,
-    ATTR_ROTATE, ATTR_CROP,
+    ATTR_ROTATE,
+    ATTR_CROP,
     ATTR_TRIM_LEFT,
     ATTR_TRIM_RIGHT,
     ATTR_TRIM_TOP,
@@ -27,23 +28,56 @@ from .const import (
     CONF_VAC_STAT,
     CONF_VACUUM_CONFIG_ENTRY_ID,
     CONF_VACUUM_ENTITY_ID,
-    COLOR_MOVE, COLOR_ROBOT, COLOR_WALL,
-    COLOR_CHARGER, COLOR_BACKGROUND, COLOR_GO_TO,
-    COLOR_NO_GO, COLOR_ZONE_CLEAN, COLOR_TEXT,
-    COLOR_ROOM_0, COLOR_ROOM_1, COLOR_ROOM_2,
-    COLOR_ROOM_3, COLOR_ROOM_4, COLOR_ROOM_5,
-    COLOR_ROOM_6, COLOR_ROOM_7, COLOR_ROOM_8,
-    COLOR_ROOM_9, COLOR_ROOM_10, COLOR_ROOM_11,
-    COLOR_ROOM_12, COLOR_ROOM_13, COLOR_ROOM_14,
+    COLOR_MOVE,
+    COLOR_ROBOT,
+    COLOR_WALL,
+    COLOR_CHARGER,
+    COLOR_BACKGROUND,
+    COLOR_GO_TO,
+    COLOR_NO_GO,
+    COLOR_ZONE_CLEAN,
+    COLOR_TEXT,
+    COLOR_ROOM_0,
+    COLOR_ROOM_1,
+    COLOR_ROOM_2,
+    COLOR_ROOM_3,
+    COLOR_ROOM_4,
+    COLOR_ROOM_5,
+    COLOR_ROOM_6,
+    COLOR_ROOM_7,
+    COLOR_ROOM_8,
+    COLOR_ROOM_9,
+    COLOR_ROOM_10,
+    COLOR_ROOM_11,
+    COLOR_ROOM_12,
+    COLOR_ROOM_13,
+    COLOR_ROOM_14,
     COLOR_ROOM_15,
-    ALPHA_BACKGROUND, ALPHA_CHARGER, ALPHA_MOVE,
-    ALPHA_NO_GO, ALPHA_WALL, ALPHA_ROBOT, ALPHA_TEXT,
-    ALPHA_GO_TO, ALPHA_ZONE_CLEAN, ALPHA_ROOM_0,
-    ALPHA_ROOM_1, ALPHA_ROOM_2, ALPHA_ROOM_3,
-    ALPHA_ROOM_4, ALPHA_ROOM_5, ALPHA_ROOM_6,
-    ALPHA_ROOM_7, ALPHA_ROOM_8, ALPHA_ROOM_9,
-    ALPHA_ROOM_10, ALPHA_ROOM_11, ALPHA_ROOM_12,
-    ALPHA_ROOM_13, ALPHA_ROOM_14, ALPHA_ROOM_15
+    ALPHA_BACKGROUND,
+    ALPHA_CHARGER,
+    ALPHA_MOVE,
+    ALPHA_NO_GO,
+    ALPHA_WALL,
+    ALPHA_ROBOT,
+    ALPHA_TEXT,
+    ALPHA_GO_TO,
+    ALPHA_ZONE_CLEAN,
+    ALPHA_ROOM_0,
+    ALPHA_ROOM_1,
+    ALPHA_ROOM_2,
+    ALPHA_ROOM_3,
+    ALPHA_ROOM_4,
+    ALPHA_ROOM_5,
+    ALPHA_ROOM_6,
+    ALPHA_ROOM_7,
+    ALPHA_ROOM_8,
+    ALPHA_ROOM_9,
+    ALPHA_ROOM_10,
+    ALPHA_ROOM_11,
+    ALPHA_ROOM_12,
+    ALPHA_ROOM_13,
+    ALPHA_ROOM_14,
+    ALPHA_ROOM_15,
 )
 from .common import (
     # get_entity_identifier_from_mqtt,
@@ -57,7 +91,8 @@ _LOGGER = logging.getLogger(__name__)
 VACUUM_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_VACUUM_ENTITY_ID): EntitySelector(
-            EntitySelectorConfig(domain=ZONE_VACUUM),)
+            EntitySelectorConfig(domain=ZONE_VACUUM),
+        )
     }
 )
 
@@ -129,8 +164,8 @@ class ValetudoCameraFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             for existing_entity in self._async_current_entries():
                 if (
-                        existing_entity.data.get(CONF_VACUUM_ENTITY_ID) == vacuum_entity.id
-                        or existing_entity.data.get(CONF_UNIQUE_ID) == unique_id
+                    existing_entity.data.get(CONF_VACUUM_ENTITY_ID) == vacuum_entity.id
+                    or existing_entity.data.get(CONF_UNIQUE_ID) == unique_id
                 ):
                     return self.async_abort(reason="already_configured")
 
@@ -191,7 +226,6 @@ class ValetudoCameraFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     "alpha_zone_clean": 25.0,
                     "alpha_background": 255.0,
                     "alpha_text": 255.0,
-
                 }
             )
 
@@ -253,7 +287,7 @@ class ValetudoCameraFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_create_entry(
                 title=vacuum_device.name + " Camera",
                 data=self.data,
-                options=self.options
+                options=self.options,
             )
 
         return self.async_show_form(
@@ -265,7 +299,7 @@ class ValetudoCameraFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(
-            config_entry: config_entries.ConfigEntry,
+        config_entry: config_entries.ConfigEntry,
     ) -> config_entries.OptionsFlow:
         """Create the options flow."""
         return OptionsFlowHandler(config_entry)
@@ -277,7 +311,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         self.config_entry = config_entry
         self.unique_id = self.config_entry.unique_id
         self.options = {}
-        _LOGGER.debug("Options edit in progress.. options before edit: ", list(self.config_entry.options.values()))
+        _LOGGER.debug(
+            "Options edit in progress.. options before edit: ",
+            list(self.config_entry.options.values()),
+        )
         options_values = list(self.config_entry.options.values())
         if len(options_values) > 0:
             config_dict: NumberSelectorConfig = {
@@ -437,10 +474,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             self.ALPHA_2_SCHEMA = vol.Schema(
                 {
                     vol.Optional(
-                        ALPHA_ROOM_0, default=config_entry.options.get("alpha_room_0"),
+                        ALPHA_ROOM_0,
+                        default=config_entry.options.get("alpha_room_0"),
                     ): NumberSelector(config_dict),
                     vol.Optional(
-                        ALPHA_ROOM_1, default=config_entry.options.get("alpha_room_1"),
+                        ALPHA_ROOM_1,
+                        default=config_entry.options.get("alpha_room_1"),
                     ): NumberSelector(config_dict),
                     vol.Optional(
                         ALPHA_ROOM_2, default=config_entry.options.get("alpha_room_2")
@@ -483,7 +522,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     ): NumberSelector(config_dict),
                     vol.Optional(
                         ALPHA_ROOM_15, default=config_entry.options.get("alpha_room_15")
-                    ): NumberSelector(config_dict)
+                    ): NumberSelector(config_dict),
                 }
             )
             _LOGGER.debug("Defined Alpha 2 Schema")


### PR DESCRIPTION
I found several issues with 1.4.1. Here's some of the fixes for them:

1. Logger code was broken (invalid syntax) in the migration code. This has been fixed and all of the logging code in that method has been changed to make it more clear which version it is referring to.
2. The migration to config entry version 2.1 (integration version 1.4.1) did not move all of the attributes to options properly. It completely forgot the ATTR_CROP_RIGHT. I also cleaned up this code to make it more clear what it is doing and make it less errorprone.

The duplicate check is completely broken still due to [these lines](https://github.com/sca075/valetudo_vacuum_camera/compare/v1.4.0..main#diff-d21885ac3e268134de25e33415abe0aa7ccf1be6575c52b0556adce966a56f89L106-L111) being removed. I don't see a way we can do the duplicate check without them.