### PR TITLE
Remove square area under robot on rendered image.

### DIFF
--- a/custom_components/valetudo_vacuum_camera/utils/draweble.py
+++ b/custom_components/valetudo_vacuum_camera/utils/draweble.py
@@ -336,10 +336,12 @@ class Drawable:
         this helps numpy to work faster and at lower
         memory cost.
         """
-        # We pick one pixel from the layer in input for the background color
-        background_color = layers[y+25, x+25]
-        # Create a 52*52 empty image numpy array
-        tmp_layer = np.full((52, 52, 4), background_color, dtype=np.uint8)
+        # Create a 52*52 image numpy array of the background behind the robot
+        top_left_x = x - 26
+        top_left_y = y - 26
+        bottom_right_x = top_left_x + 52
+        bottom_right_y = top_left_y + 52
+        tmp_layer = layers[top_left_y:bottom_right_y, top_left_x:bottom_right_x].copy()
         # centre of the above array is used from the rest of the code.
         # to draw the robot.
         tmp_x, tmp_y = 26, 26


### PR DESCRIPTION
Removes the square background behind the robot. Example:
![image](https://github.com/sca075/valetudo_vacuum_camera/assets/675005/0e6d255f-de6b-467a-a035-48df2107fd15)

