### PR TITLE
fix Rand256 reboot 3AM warning issue.

### DIFF
--- a/custom_components/valetudo_vacuum_camera/valetudo/rand256/image_handler.py
+++ b/custom_components/valetudo_vacuum_camera/valetudo/rand256/image_handler.py
@@ -288,7 +288,7 @@ class ReImageHandler(object):
         self.active_zones = self.shared.rand256_active_zone
 
         try:
-            if m_json is not None:
+            if (m_json is not None) and (not isinstance(m_json, tuple)):
                 _LOGGER.info(self.file_name + ":Composing the image for the camera.")
                 # buffer json data
                 self.json_data = m_json


### PR DESCRIPTION
At 3AM the robot reboot and a warning come out due to improper image data.