### PR TITLE
Renamed Rooms options Restore 

### DIFF
--- a/custom_components/valetudo_vacuum_camera/manifest.json
+++ b/custom_components/valetudo_vacuum_camera/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/sca075/valetudo_vacuum_camera/issues",
     "requirements": ["pillow==10.3.0", "numpy"],
-    "version": "2024.06.0b1"
+    "version": "2024.06.0b3"
 }

--- a/custom_components/valetudo_vacuum_camera/snapshots/snapshot.py
+++ b/custom_components/valetudo_vacuum_camera/snapshots/snapshot.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.storage import STORAGE_DIR
 
 from custom_components.valetudo_vacuum_camera.types import Any, JsonType, PilPNG
 from custom_components.valetudo_vacuum_camera.utils.users_data import (
-    async_write_languages_json,
+    async_write_languages_json
 )
 
 _LOGGER = logging.getLogger(__name__)  # Create a logger instance
@@ -40,8 +40,12 @@ class Snapshots:
     async def async_get_room_data(self) -> None:
         """Get the Vacuum Rooms data and save it to a file."""
         vacuum_id = self.file_name
+        # New file room_data to be saved / updated
         data_file_path = os.path.join(self.storage_path, f"room_data_{vacuum_id}.json")
         un_formated_room_data = self._shared.map_rooms
+        if not un_formated_room_data:
+            _LOGGER.debug(f"No rooms data found for {vacuum_id} to save.")
+            return
         room_data = {}
         for room_id, room_info in un_formated_room_data.items():
             room_data[room_id] = {


### PR DESCRIPTION
When updating the camera via HACS the renamed colours descriptions  will be overwriten as default.
The rooms colours description will be therefore rewriten at home assistant reboot (required to load the camera updated code).
The values in the rooms colurs descriptions will be updated for the last vacuum that runned the **rename rooms** functions.
If none, the rooms remain with the default name. Same default name will be for vacuums that do not support or have segments configured.