### PR TITLE
Updated get_room_count

### DIFF
--- a/custom_components/valetudo_vacuum_camera/const.py
+++ b/custom_components/valetudo_vacuum_camera/const.py
@@ -6,6 +6,7 @@
 PLATFORMS = ["camera"]
 DOMAIN = "valetudo_vacuum_camera"
 DEFAULT_NAME = "valetudo vacuum camera"
+DEFAULT_ROOMS = 15
 ATTR_ROTATE = "rotate_image"
 ATTR_CROP = "crop_image"
 ATTR_MARGINS = "margins"

--- a/custom_components/valetudo_vacuum_camera/const.py
+++ b/custom_components/valetudo_vacuum_camera/const.py
@@ -1,6 +1,6 @@
 """Constants for the valetudo_vacuum_camera integration."""
 
-"""Version v2024.06.2"""
+"""Version v2024.06.3b2"""
 
 """Required in Config_Flow"""
 PLATFORMS = ["camera"]

--- a/custom_components/valetudo_vacuum_camera/manifest.json
+++ b/custom_components/valetudo_vacuum_camera/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/sca075/valetudo_vacuum_camera/issues",
     "requirements": ["pillow==10.3.0", "numpy"],
-    "version": "2024.06.3b1"
+    "version": "2024.06.3b2"
 }

--- a/custom_components/valetudo_vacuum_camera/utils/users_data.py
+++ b/custom_components/valetudo_vacuum_camera/utils/users_data.py
@@ -17,6 +17,9 @@ from typing import Optional
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import STORAGE_DIR
 
+
+from custom_components.valetudo_vacuum_camera.const import DEFAULT_ROOMS
+
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
@@ -28,14 +31,14 @@ def get_rooms_count(robot_name: str) -> int:
     try:
         with open(file_path) as file:
             room_data = json.load(file)
-            room_count = room_data.get("segments", 0)
+            room_count = room_data.get("segments", DEFAULT_ROOMS)
             return room_count
     except FileNotFoundError:
         _LOGGER.debug(f"File not found: {file_path}")
-        return 0
+        return DEFAULT_ROOMS
     except json.JSONDecodeError:
         _LOGGER.error(f"Error decoding file: {file_path}")
-        return 0
+        return DEFAULT_ROOMS
 
 
 async def async_write_vacuum_id(storage_dir, vacuum_id):

--- a/custom_components/valetudo_vacuum_camera/utils/users_data.py
+++ b/custom_components/valetudo_vacuum_camera/utils/users_data.py
@@ -3,7 +3,7 @@ Common functions for the Valetudo Vacuum Camera integration.
 Those functions are used to store and retrieve user data from the Home Assistant storage.
 The data will be stored locally in the Home Assistant in .storage/valetudo_camera directory.
 Author: @sca075
-Version: 2024.06.3b1
+Version: 2024.06.3b2
 """
 
 from __future__ import annotations


### PR DESCRIPTION
get_room_count should normally return 0 only if segements are not detected. In some cases the room_count  fails probably because of the the path. 
The default rooms count will be 15 instead of 0 (all room colour options enable instead of 1) this should fix #160. 
In any cases there is to understand why this failed, the get_room_data will raise now a warning in the case the file with room data isn't found. 